### PR TITLE
Add minimal kit bill of materials and specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,6 +492,117 @@
         height: 12px;
       }
 
+      .bom-grid {
+        margin-top: clamp(1.75rem, 3.5vw, 2.3rem);
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: start;
+      }
+
+      .bom-table-wrapper {
+        background: var(--surface-alt);
+        border: 1px solid var(--surface-border-subtle);
+        border-radius: 18px;
+        padding: clamp(1.1rem, 2.5vw, 1.6rem);
+        overflow-x: auto;
+      }
+
+      .bom-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.96rem;
+      }
+
+      .bom-table thead th {
+        text-align: left;
+        padding-bottom: 0.75rem;
+        font-size: 0.82rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .bom-table tbody td {
+        padding: 0.75rem 0;
+        border-top: 1px solid var(--surface-border-subtle);
+        vertical-align: top;
+        color: var(--text-quaternary);
+        line-height: 1.6;
+      }
+
+      .bom-table tbody tr:first-child td {
+        border-top: none;
+      }
+
+      .bom-table strong {
+        color: var(--text-secondary);
+        font-weight: 600;
+      }
+
+      .bom-specs {
+        display: grid;
+        gap: clamp(1.1rem, 2.5vw, 1.6rem);
+      }
+
+      .bom-specs article {
+        background: var(--surface-alt);
+        border: 1px solid var(--surface-border-subtle);
+        border-radius: 18px;
+        padding: clamp(1.1rem, 2.3vw, 1.5rem);
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .bom-specs h3 {
+        margin: 0;
+        font-size: 1.12rem;
+        letter-spacing: -0.01em;
+      }
+
+      .bom-specs p,
+      .bom-specs li {
+        margin: 0;
+        font-size: 0.96rem;
+        line-height: 1.65;
+        color: var(--text-quaternary);
+      }
+
+      .bom-specs ul {
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.55rem;
+      }
+
+      .bom-specs li strong {
+        color: var(--text-secondary);
+        font-weight: 600;
+      }
+
+      .schematic {
+        margin-top: clamp(1.9rem, 4vw, 2.6rem);
+        background: var(--surface-alt);
+        border: 1px solid var(--surface-border-subtle);
+        border-radius: 20px;
+        padding: clamp(1.2rem, 2.5vw, 1.8rem);
+        display: grid;
+        gap: 0.85rem;
+      }
+
+      .schematic svg {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      .schematic figcaption {
+        margin: 0;
+        text-align: center;
+        font-size: 0.9rem;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
       .dual-grid {
         margin-top: clamp(1.6rem, 3vw, 2.1rem);
         display: grid;
@@ -1220,6 +1331,212 @@
             </ul>
           </article>
         </div>
+      </section>
+
+      <section class="panel bom">
+        <h2>Minimal Deployment Bill of Materials</h2>
+        <p>
+          A four-pole starter kit keeps the Levitree architecture lean while preserving the
+          optical filtering, synchronous detection, and telemetry paths proven in feasibility
+          testing. The components below cover the light source, sensing nodes, timing, and
+          infrastructure required to stage a daylight-capable pilot.
+        </p>
+        <div class="bom-grid">
+          <div class="bom-table-wrapper">
+            <table class="bom-table">
+              <thead>
+                <tr>
+                  <th scope="col">Subsystem</th>
+                  <th scope="col">Example component</th>
+                  <th scope="col">Qty</th>
+                  <th scope="col">Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Control &amp; processing hub</td>
+                  <td>
+                    <strong>STM32F405 Nucleo-64</strong> on a carrier with dual AD7609 16-bit ADCs
+                    and isolated RS-485 interface
+                  </td>
+                  <td>1</td>
+                  <td>Runs modulation control, lock-in demodulation, and packages telemetry for Ethernet MQTT uplink.</td>
+                </tr>
+                <tr>
+                  <td>Laser emission assembly</td>
+                  <td>
+                    <strong>532&nbsp;nm 80–100&nbsp;mW DPSS module</strong> with TTL driver (e.g.,
+                    LaserGlow LRS-0532 + OEM-TTL driver)
+                  </td>
+                  <td>1</td>
+                  <td>Provides the green reference beam with 0–5&nbsp;V gating up to 12&nbsp;kHz and integrated TEC cooling.</td>
+                </tr>
+                <tr>
+                  <td>Per-pole optical stack</td>
+                  <td>
+                    <strong>10&nbsp;nm 532&nbsp;nm bandpass filter</strong> + wire-grid polarizer +
+                    adjustable iris (Thorlabs FBH532-10, WP25M-UB, SM1D12C set)
+                  </td>
+                  <td>4 kits</td>
+                  <td>Threads into each pole enclosure ahead of the sensor ladder to maintain ambient rejection.</td>
+                </tr>
+                <tr>
+                  <td>Sensor pole electronics</td>
+                  <td>
+                    <strong>16-tap LDR ladder PCB</strong> with AD8616 TIA, MAX1487 RS-485 node, and
+                    keyed service connectors
+                  </td>
+                  <td>4</td>
+                  <td>Captures vertical displacement, performs on-node ON/OFF averaging, and streams digitized frames to the hub.</td>
+                </tr>
+                <tr>
+                  <td>Timing reference</td>
+                  <td>
+                    <strong>u-blox NEO-M9N GNSS receiver</strong> with buffered 1PPS and 10&nbsp;MHz
+                    VCXO disciplining board
+                  </td>
+                  <td>1</td>
+                  <td>Holds modulation frequency within ±2&nbsp;ppm and distributes phase markers to every pole.</td>
+                </tr>
+                <tr>
+                  <td>Power &amp; cabling kit</td>
+                  <td>
+                    <strong>24&nbsp;V&nbsp;DC 150&nbsp;W supply</strong>, 5&nbsp;V/3.3&nbsp;V buck modules,
+                    and 18&nbsp;AWG shielded power/RS-485 trunk lines
+                  </td>
+                  <td>1 set</td>
+                  <td>Feeds the laser, hub, and poles with surge suppression and keyed connectors for field swaps.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="bom-specs">
+            <article>
+              <h3>Communication Protocols</h3>
+              <ul>
+                <li>
+                  <strong>RS-485 multi-drop bus:</strong> Half-duplex 921.6&nbsp;kbps (8N1) with
+                  CRC-16 on each 64-byte frame; the hub polls four pole addresses in a 4&nbsp;ms
+                  window to maintain deterministic latency.
+                </li>
+                <li>
+                  <strong>Modulation sync line:</strong> LVDS pair carrying a 10&nbsp;kHz square wave
+                  plus frame-start strobe so lock-in demodulators stay phase-aligned with the laser.
+                </li>
+                <li>
+                  <strong>Uplink:</strong> Hub publishes JSON telemetry via MQTT over 100BASE-TX
+                  Ethernet (or Wi-Fi backhaul) every 250&nbsp;ms with optional TLS and VPN tunneling
+                  for remote observers.
+                </li>
+              </ul>
+            </article>
+            <article>
+              <h3>Power Budget</h3>
+              <p>The minimal kit runs from a single 24&nbsp;V&nbsp;DC source or field battery pack.</p>
+              <ul>
+                <li><strong>Laser head:</strong> 9.5&nbsp;W typical, 14&nbsp;W peak during TEC warm-up.</li>
+                <li><strong>Sensor pole:</strong> 1.3&nbsp;W @ 9&nbsp;V for LDR bias, analog front end, and RS-485 node.</li>
+                <li><strong>Central hub &amp; GNSS:</strong> 4.1&nbsp;W @ 5&nbsp;V with Ethernet and MQTT active.</li>
+              </ul>
+              <p>
+                <strong>Total draw:</strong> ~17.6&nbsp;W continuous for four poles; reserve 25&nbsp;W to
+                cover laser startup and environmental overhead.
+              </p>
+            </article>
+            <article>
+              <h3>Clock &amp; Timing Sources</h3>
+              <ul>
+                <li><strong>Hub MCU clock:</strong> 168&nbsp;MHz core with 84&nbsp;MHz timer driving dual 10&nbsp;kHz PWM modulators.</li>
+                <li><strong>ADC sampling:</strong> 200&nbsp;kS/s aggregate per pole, performing four-phase synchronous demodulation into 24-bit accumulators.</li>
+                <li><strong>1PPS disciplining:</strong> GNSS 1PPS and 10&nbsp;MHz VCXO hold modulation jitter below 80&nbsp;ns and frequency error below ±2&nbsp;ppm.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+        <figure class="schematic">
+          <svg viewBox="0 0 780 300" role="img" aria-labelledby="schematic-title">
+            <title id="schematic-title">Minimal kit power, timing, and communications overview</title>
+            <desc>
+              Diagram showing the laser driver, sensor poles on an RS-485 and power trunk, GNSS
+              timing distribution, and the hub uplink to the operations dashboard.
+            </desc>
+            <g fill="#0f172a" stroke="#38bdf8" stroke-width="2">
+              <rect x="40" y="40" width="200" height="70" rx="14" ry="14" />
+              <rect x="300" y="30" width="220" height="110" rx="14" ry="14" />
+              <rect x="570" y="50" width="160" height="70" rx="14" ry="14" />
+              <rect x="60" y="160" width="220" height="90" rx="14" ry="14" />
+              <rect x="330" y="160" width="160" height="70" rx="14" ry="14" />
+              <rect x="540" y="180" width="180" height="90" rx="14" ry="14" />
+            </g>
+            <g fill="#e2e8f0" font-family="Inter, 'Segoe UI', sans-serif" font-size="14">
+              <text text-anchor="middle">
+                <tspan x="140" y="70">Laser Source</tspan>
+                <tspan x="140" y="88">+ TTL Driver</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="410" y="72">Central Hub MCU</tspan>
+                <tspan x="410" y="90">Lock-in DSP &amp; RS-485</tspan>
+                <tspan x="410" y="108">100BASE-TX MQTT</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="650" y="82">Operations</tspan>
+                <tspan x="650" y="100">Dashboard / SCADA</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="170" y="198">Sensor Pole Interface</tspan>
+                <tspan x="170" y="216">Lock-in Node (×4)</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="410" y="192">GNSS 1PPS &amp;</tspan>
+                <tspan x="410" y="210">10&nbsp;MHz Fan-out</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="630" y="212">24&nbsp;V&nbsp;DC Supply</tspan>
+                <tspan x="630" y="230">&amp; Buck Regulation</tspan>
+              </text>
+            </g>
+            <g stroke="#38bdf8" stroke-width="2" stroke-linecap="round" fill="none">
+              <line x1="240" y1="75" x2="300" y2="75" />
+              <line x1="520" y1="85" x2="570" y2="85" />
+              <path d="M280 205H300V140" />
+              <line x1="410" y1="160" x2="410" y2="140" />
+              <path d="M550 225H520V140" />
+              <line x1="550" y1="240" x2="280" y2="240" />
+              <path d="M550 210H240V110" />
+            </g>
+            <g fill="#38bdf8" stroke="#0f172a" stroke-width="1.5">
+              <circle cx="300" cy="75" r="4" />
+              <circle cx="520" cy="85" r="4" />
+              <circle cx="300" cy="140" r="4" />
+              <circle cx="410" cy="140" r="4" />
+              <circle cx="520" cy="140" r="4" />
+              <circle cx="520" cy="225" r="4" />
+              <circle cx="280" cy="240" r="4" />
+              <circle cx="240" cy="110" r="4" />
+            </g>
+            <g fill="#94a3b8" font-family="Inter, 'Segoe UI', sans-serif" font-size="12">
+              <text text-anchor="middle">
+                <tspan x="270" y="62">10&nbsp;kHz TTL gating</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="545" y="72">MQTT / TLS</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="330" y="188">RS-485 + CRC</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="410" y="154">1PPS</tspan>
+              </text>
+              <text text-anchor="middle">
+                <tspan x="420" y="232">24&nbsp;V trunk &amp; regulation</tspan>
+              </text>
+            </g>
+          </svg>
+          <figcaption>
+            Block diagram of the minimal kit showing laser drive, pole interfaces on the RS-485
+            and power trunk, GNSS-timed clock distribution, and the MQTT uplink path.
+          </figcaption>
+        </figure>
       </section>
 
       <section class="panel metrics">


### PR DESCRIPTION
## Summary
- add a dedicated bill of materials section for a four-pole minimal deployment kit
- document communication protocols, power budget, clock sources, and include a schematic-style diagram
- extend the page stylesheet to support the new table, spec cards, and figure layout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ca46c5e6fc8329ac26b238179ec9c7