### PR TITLE
Display exact update timestamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -901,7 +901,10 @@
     </button>
     <main>
       <section class="hero">
-        <span class="eyebrow">Feasibility Update · Updated September 2025</span>
+        <span class="eyebrow"
+          >Feasibility Update · Updated
+          <time id="update-timestamp" datetime="">September 2025</time></span
+        >
         <h1>Distributed Laser-Level Monitoring for Soil Stabilization</h1>
         <p>
           Summarizing the latest study on a central 532&nbsp;nm reference beam and remote
@@ -1815,6 +1818,30 @@
         </ul>
       </section>
     </main>
+
+    <script>
+      (function () {
+        const timestampEl = document.getElementById("update-timestamp");
+        if (!timestampEl) return;
+
+        const modified = new Date(document.lastModified);
+        if (Number.isNaN(modified.getTime())) return;
+
+        const formatter = new Intl.DateTimeFormat("en-US", {
+          timeZone: "UTC",
+          year: "numeric",
+          month: "long",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+          timeZoneName: "short",
+        });
+
+        timestampEl.textContent = formatter.format(modified);
+        timestampEl.dateTime = modified.toISOString();
+      })();
+    </script>
 
     <footer>
       <p>


### PR DESCRIPTION
## Summary
- replace the hero eyebrow text with a semantic time element so the update label can show an exact timestamp
- add a lightweight script that formats the document's last modified date in UTC with hours and minutes and stores it in the time element

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca48ec6f248329be2733c9ba6ede90