### PR TITLE
Implement accessible BOM tab interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,12 +558,64 @@
         height: 12px;
       }
 
-      .bom-grid {
+      .bom-tabs {
         margin-top: clamp(1.75rem, 3.5vw, 2.3rem);
         display: grid;
         gap: clamp(1.4rem, 3vw, 2rem);
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        align-items: start;
+      }
+
+      .bom-tablist {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+      }
+
+      .bom-tab {
+        appearance: none;
+        border: 1px solid var(--surface-border-subtle);
+        background: var(--surface-alt);
+        color: var(--text-tertiary);
+        border-radius: 999px;
+        padding: 0.65rem 1.35rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        transition: color 150ms ease, background 150ms ease, border-color 150ms ease,
+          box-shadow 150ms ease, transform 150ms ease;
+        cursor: pointer;
+      }
+
+      .bom-tab:hover,
+      .bom-tab:focus-visible {
+        border-color: var(--accent-border);
+        color: var(--accent);
+      }
+
+      .bom-tab:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 3px;
+      }
+
+      .bom-tab[aria-selected="true"] {
+        background: linear-gradient(135deg, var(--accent-soft), rgba(56, 189, 248, 0.12));
+        border-color: var(--accent-border);
+        color: var(--accent);
+        box-shadow: 0 16px 32px -22px rgba(56, 189, 248, 0.8);
+      }
+
+      .bom-tab[aria-selected="true"]:hover {
+        transform: translateY(-1px);
+      }
+
+      .bom-panels {
+        display: grid;
+        gap: clamp(1.6rem, 3.2vw, 2.2rem);
+      }
+
+      .bom-tabpanel {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
       }
 
       .bom-table-wrapper {
@@ -607,6 +659,7 @@
       }
 
       .bom-specs {
+        margin-top: clamp(1.6rem, 3.2vw, 2.4rem);
         display: grid;
         gap: clamp(1.1rem, 2.5vw, 1.6rem);
       }
@@ -1575,9 +1628,54 @@
           a cross-check that the subsystem-level wiring and timing still land in the same system
           topology.
         </p>
-        <div class="bom-grid">
-          <div class="bom-subsections">
-            <article class="bom-subsystem" id="bom-transmitter">
+        <div class="bom-tabs" data-tabs>
+          <div
+            class="bom-tablist"
+            role="tablist"
+            aria-label="Bill of materials subsystems"
+          >
+            <button
+              type="button"
+              class="bom-tab"
+              id="bom-tab-transmitter"
+              role="tab"
+              aria-selected="true"
+              aria-controls="bom-transmitter"
+              tabindex="0"
+            >
+              Transmitter
+            </button>
+            <button
+              type="button"
+              class="bom-tab"
+              id="bom-tab-receiver"
+              role="tab"
+              aria-selected="false"
+              aria-controls="bom-receiver"
+              tabindex="-1"
+            >
+              Receiver
+            </button>
+            <button
+              type="button"
+              class="bom-tab"
+              id="bom-tab-communications"
+              role="tab"
+              aria-selected="false"
+              aria-controls="bom-communications"
+              tabindex="-1"
+            >
+              Communications
+            </button>
+          </div>
+          <div class="bom-panels">
+            <article
+              class="bom-subsystem bom-tabpanel"
+              id="bom-transmitter"
+              role="tabpanel"
+              tabindex="0"
+              aria-labelledby="bom-tab-transmitter"
+            >
               <h3>Transmitter: Laser Emission &amp; Conditioning</h3>
               <p>
                 The transmitter package gates the 532&nbsp;nm DPSS laser, stabilizes its thermal load,
@@ -1733,7 +1831,14 @@
                 </table>
               </div>
             </article>
-            <article class="bom-subsystem" id="bom-receiver">
+            <article
+              class="bom-subsystem bom-tabpanel"
+              id="bom-receiver"
+              role="tabpanel"
+              tabindex="0"
+              aria-labelledby="bom-tab-receiver"
+              hidden
+            >
               <h3>Receiver: Sensor Pole Optics &amp; Front-End</h3>
               <p>
                 Each pole combines optical rejection, synchronous detection, and balanced data
@@ -1910,7 +2015,14 @@
                 </table>
               </div>
             </article>
-            <article class="bom-subsystem" id="bom-communications">
+            <article
+              class="bom-subsystem bom-tabpanel"
+              id="bom-communications"
+              role="tabpanel"
+              tabindex="0"
+              aria-labelledby="bom-tab-communications"
+              hidden
+            >
               <h3>Communication &amp; Timing Backbone</h3>
               <p>
                 The communication layer maintains synchronous modulation, collects demodulated
@@ -2079,60 +2191,60 @@
               </div>
             </article>
           </div>
-          <div class="bom-specs">
-            <article>
-              <h3>Communication Protocols</h3>
-              <p>
-                Refer to Figure&nbsp;C.1 for the physical topology behind these links and to the
-                communication BOM above for the exact hardware to terminate each span.
-              </p>
-              <ul>
-                <li>
-                  <strong>RS-485 multi-drop bus:</strong> Half-duplex 921.6&nbsp;kbps (8N1) with
-                  CRC-16 on each 64-byte frame; the hub polls four pole addresses in a 4&nbsp;ms
-                  window to maintain deterministic latency.
-                </li>
-                <li>
-                  <strong>Modulation sync line:</strong> LVDS pair carrying a 10&nbsp;kHz square wave
-                  plus frame-start strobe so lock-in demodulators stay phase-aligned with the laser.
-                </li>
-                <li>
-                  <strong>Uplink:</strong> Hub publishes JSON telemetry via MQTT over 100BASE-TX
-                  Ethernet (or Wi-Fi backhaul) every 250&nbsp;ms with optional TLS and VPN tunneling
-                  for remote observers.
-                </li>
-              </ul>
-            </article>
-            <article>
-              <h3>Power Budget</h3>
-              <p>
-                The minimal kit runs from a single 24&nbsp;V&nbsp;DC source or field battery pack. Power
-                entry, conditioning, and regulation stages are depicted in Figures&nbsp;T.1, R.1, and
-                C.1 for reference during integration.
-              </p>
-              <ul>
-                <li><strong>Laser head:</strong> 9.5&nbsp;W typical, 14&nbsp;W peak during TEC warm-up.</li>
-                <li><strong>Sensor pole:</strong> 1.3&nbsp;W @ 9&nbsp;V for LDR bias, analog front end, and RS-485 node.</li>
-                <li><strong>Central hub &amp; GNSS:</strong> 4.1&nbsp;W @ 5&nbsp;V with Ethernet and MQTT active.</li>
-              </ul>
-              <p>
-                <strong>Total draw:</strong> ~17.6&nbsp;W continuous for four poles; reserve 25&nbsp;W to
-                cover laser startup and environmental overhead.
-              </p>
-            </article>
-            <article>
-              <h3>Clock &amp; Timing Sources</h3>
-              <p>
-                Figure&nbsp;C.1 also annotates the GNSS timing fan-out so installers can trace the 1PPS
-                and 10&nbsp;MHz discipline points alongside the communication BOM part numbers.
-              </p>
-              <ul>
-                <li><strong>Hub MCU clock:</strong> 168&nbsp;MHz core with 84&nbsp;MHz timer driving dual 10&nbsp;kHz PWM modulators.</li>
-                <li><strong>ADC sampling:</strong> 200&nbsp;kS/s aggregate per pole, performing four-phase synchronous demodulation into 24-bit accumulators.</li>
-                <li><strong>1PPS disciplining:</strong> GNSS 1PPS and 10&nbsp;MHz VCXO hold modulation jitter below 80&nbsp;ns and frequency error below ±2&nbsp;ppm.</li>
-              </ul>
-            </article>
-          </div>
+        </div>
+        <div class="bom-specs">
+          <article>
+            <h3>Communication Protocols</h3>
+            <p>
+              Refer to Figure&nbsp;C.1 for the physical topology behind these links and to the
+              communication BOM above for the exact hardware to terminate each span.
+            </p>
+            <ul>
+              <li>
+                <strong>RS-485 multi-drop bus:</strong> Half-duplex 921.6&nbsp;kbps (8N1) with
+                CRC-16 on each 64-byte frame; the hub polls four pole addresses in a 4&nbsp;ms
+                window to maintain deterministic latency.
+              </li>
+              <li>
+                <strong>Modulation sync line:</strong> LVDS pair carrying a 10&nbsp;kHz square wave
+                plus frame-start strobe so lock-in demodulators stay phase-aligned with the laser.
+              </li>
+              <li>
+                <strong>Uplink:</strong> Hub publishes JSON telemetry via MQTT over 100BASE-TX
+                Ethernet (or Wi-Fi backhaul) every 250&nbsp;ms with optional TLS and VPN tunneling
+                for remote observers.
+              </li>
+            </ul>
+          </article>
+          <article>
+            <h3>Power Budget</h3>
+            <p>
+              The minimal kit runs from a single 24&nbsp;V&nbsp;DC source or field battery pack. Power
+              entry, conditioning, and regulation stages are depicted in Figures&nbsp;T.1, R.1, and
+              C.1 for reference during integration.
+            </p>
+            <ul>
+              <li><strong>Laser head:</strong> 9.5&nbsp;W typical, 14&nbsp;W peak during TEC warm-up.</li>
+              <li><strong>Sensor pole:</strong> 1.3&nbsp;W @ 9&nbsp;V for LDR bias, analog front end, and RS-485 node.</li>
+              <li><strong>Central hub &amp; GNSS:</strong> 4.1&nbsp;W @ 5&nbsp;V with Ethernet and MQTT active.</li>
+            </ul>
+            <p>
+              <strong>Total draw:</strong> ~17.6&nbsp;W continuous for four poles; reserve 25&nbsp;W to
+              cover laser startup and environmental overhead.
+            </p>
+          </article>
+          <article>
+            <h3>Clock &amp; Timing Sources</h3>
+            <p>
+              Figure&nbsp;C.1 also annotates the GNSS timing fan-out so installers can trace the 1PPS
+              and 10&nbsp;MHz discipline points alongside the communication BOM part numbers.
+            </p>
+            <ul>
+              <li><strong>Hub MCU clock:</strong> 168&nbsp;MHz core with 84&nbsp;MHz timer driving dual 10&nbsp;kHz PWM modulators.</li>
+              <li><strong>ADC sampling:</strong> 200&nbsp;kS/s aggregate per pole, performing four-phase synchronous demodulation into 24-bit accumulators.</li>
+              <li><strong>1PPS disciplining:</strong> GNSS 1PPS and 10&nbsp;MHz VCXO hold modulation jitter below 80&nbsp;ns and frequency error below ±2&nbsp;ppm.</li>
+            </ul>
+          </article>
         </div>
         <figure class="schematic">
           <svg viewBox="0 0 780 300" role="img" aria-labelledby="schematic-title">
@@ -2283,8 +2395,110 @@
             </p>
           </li>
         </ul>
-      </section>
-    </main>
+    </section>
+  </main>
+
+    <script>
+      (function () {
+        const tabContainers = document.querySelectorAll("[data-tabs]");
+        tabContainers.forEach((container) => {
+          const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+          if (tabs.length === 0) {
+            return;
+          }
+
+          const panels = tabs
+            .map((tab) => {
+              const controls = tab.getAttribute("aria-controls");
+              return controls ? container.querySelector(`#${controls}`) : null;
+            })
+            .filter((panel) => panel);
+
+          if (panels.length === 0) {
+            return;
+          }
+
+          let activeTab =
+            tabs.find((tab) => tab.getAttribute("aria-selected") === "true") ||
+            tabs[0];
+
+          const activate = (tab, { focus = true } = {}) => {
+            if (!tab) {
+              return;
+            }
+
+            activeTab = tab;
+
+            tabs.forEach((currentTab) => {
+              const isActive = currentTab === tab;
+              currentTab.setAttribute("aria-selected", String(isActive));
+              currentTab.setAttribute("tabindex", isActive ? "0" : "-1");
+              const controls = currentTab.getAttribute("aria-controls");
+              const panel = controls
+                ? container.querySelector(`#${controls}`)
+                : null;
+              if (panel) {
+                if (isActive) {
+                  panel.removeAttribute("hidden");
+                } else {
+                  panel.setAttribute("hidden", "");
+                }
+              }
+            });
+
+            if (focus) {
+              tab.focus();
+            }
+          };
+
+          activate(activeTab, { focus: false });
+
+          tabs.forEach((tab) => {
+            tab.addEventListener("click", () => {
+              activate(tab, { focus: false });
+            });
+
+            tab.addEventListener("keydown", (event) => {
+              const { key } = event;
+              switch (key) {
+                case "ArrowLeft":
+                case "ArrowUp":
+                case "ArrowRight":
+                case "ArrowDown":
+                case "Home":
+                case "End":
+                  event.preventDefault();
+                  break;
+                default:
+                  return;
+              }
+
+              const currentIndex = tabs.indexOf(tab);
+              if (currentIndex === -1) {
+                return;
+              }
+
+              let nextIndex = currentIndex;
+
+              if (key === "Home") {
+                nextIndex = 0;
+              } else if (key === "End") {
+                nextIndex = tabs.length - 1;
+              } else if (key === "ArrowLeft" || key === "ArrowUp") {
+                nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+              } else if (key === "ArrowRight" || key === "ArrowDown") {
+                nextIndex = (currentIndex + 1) % tabs.length;
+              }
+
+              const nextTab = tabs[nextIndex];
+              if (nextTab) {
+                activate(nextTab);
+              }
+            });
+          });
+        });
+      })();
+    </script>
 
     <script>
       (function () {


### PR DESCRIPTION
## Summary
- replace the static BOM grid with an ARIA tablist so transmitter, receiver, and communications content is grouped into focused panels
- move the supplemental BOM specifications below the tab component to avoid the previous asymmetric column layout
- extend the stylesheet and add a small script to style, toggle, and keyboard-navigate the new tabs while preserving theme support

## Testing
- browser_container.run_playwright_script (tablist smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68ca4d4a3ad88329bfee508e478c108c